### PR TITLE
Add support XMLNAME and XMLITEMNAME

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="objectscript-openapi-definition.ZPM">
     <Module>
       <Name>objectscript-openapi-definition</Name>
-      <Version>1.3.0</Version>
+      <Version>1.3.1</Version>
       <Description>The objectif of this library is to generate the ObjectScript Class from an OpenApi defintion.</Description>
       <Packaging>module</Packaging>
       <SourcesRoot>src</SourcesRoot>

--- a/src/Grongier/OpenApi/DefinitionV3.cls
+++ b/src/Grongier/OpenApi/DefinitionV3.cls
@@ -114,6 +114,8 @@ Method GenerateProperties(classDef As %Dictionary.ClassDefinition, properties As
             Do ..GenerateClassModel(property, propDef.Type)
         
         } ElseIf property.type = "array" {
+            
+            Do XMLParameters
 
             Set propDef.Collection = "list"
             
@@ -128,6 +130,8 @@ Method GenerateProperties(classDef As %Dictionary.ClassDefinition, properties As
                 ; We have to check if the reference is type object or a primitive.
                 Set refObject = ..GetObjectByRef(property.items."$ref", .name)
                 Continue:'$IsObject(refObject)
+                
+                
                 
                 Set propDef.Type = $Select(refObject.type="object": ..package _ "." _name, 1: ..GetObjectScriptType(refObject.type, refObject.format))
                 Set pObj = refObject
@@ -181,9 +185,14 @@ AdditionalPropertySettings
 
         Do propDef.Parameters.SetAt(valueList,"VALUELIST")        
     }
+    
+    Do XMLParameters
 
+    Quit
+
+XMLParameters
     If ..super [ "%XML.Adaptor" {
-        If $IsObject(pObj.xml), pObj.xml.name '= "" Do propDef.Parameters.SetAt(pObj.xml.name, "XMLNAME")
+        If $IsObject(pObj.xml), pObj.xml.name '= "" Do propDef.Parameters.SetAt(pObj.xml.name, $Select(propDef.Collection = "list":"XMLITEMNAME",1:"XMLNAME"))
         If $IsObject(pObj.items), $IsObject(pObj.items.xml), pObj.items.xml.name '= "" Do propDef.Parameters.SetAt(pObj.items.xml.name, "XMLITEMNAME")
     }
 

--- a/src/Grongier/OpenApi/DefinitionV3.cls
+++ b/src/Grongier/OpenApi/DefinitionV3.cls
@@ -182,6 +182,11 @@ AdditionalPropertySettings
         Do propDef.Parameters.SetAt(valueList,"VALUELIST")        
     }
 
+    If ..super [ "%XML.Adaptor" {
+        If $IsObject(pObj.xml), pObj.xml.name '= "" Do propDef.Parameters.SetAt(pObj.xml.name, "XMLNAME")
+        If $IsObject(pObj.items), $IsObject(pObj.items.xml), pObj.items.xml.name '= "" Do propDef.Parameters.SetAt(pObj.items.xml.name, "XMLITEMNAME")
+    }
+
     Quit
 }
 


### PR DESCRIPTION
Salut  @grongierisc,

Ma prochaine étape pour OpenAPI-Suite est la génération de code plus étendue pour le media type `application/xml`.
J'ai ajouté le support des properties parameters `XMLNAME` et `XMLITEMNAME` si le modèle hérite de %XML.Adaptor.
Ce sera très utile pour avoir un code généré plus complet.

Merci!